### PR TITLE
Creates endpoint for event-types with GET, POST, PATCH, DELETE

### DIFF
--- a/backend/__tests__/admin/adminEventEndPoints.test.js
+++ b/backend/__tests__/admin/adminEventEndPoints.test.js
@@ -131,8 +131,8 @@ describe("Admin Events API", () => {
     });
   });
 
-  describe("PUT /api/admin/events/:id", () => {
-    test("200 - PUT: responds with updated event when admin", async () => {
+  describe("PATCH /api/admin/events/:id", () => {
+    test("200 - PATCH: responds with updated event when admin", async () => {
       const updateData = {
         title: "Updated Event",
         description: "Updated Description",
@@ -149,7 +149,7 @@ describe("Admin Events API", () => {
       };
 
       const response = await request(app)
-        .put("/api/admin/events/1")
+        .patch("/api/admin/events/1")
         .set("user-role", "admin")
         .send(updateData);
 
@@ -167,9 +167,9 @@ describe("Admin Events API", () => {
       });
     });
 
-    test("404 - PUT: responds with error when event not found", async () => {
+    test("404 - PATCH: responds with error when event not found", async () => {
       const response = await request(app)
-        .put("/api/admin/events/999")
+        .patch("/api/admin/events/999")
         .set("user-role", "admin")
         .send({
           title: "Not Found Event",
@@ -188,9 +188,9 @@ describe("Admin Events API", () => {
       expect(response.body.message).toBe("Event not found");
     });
 
-    test("403 - PUT: responds with error when not admin", async () => {
+    test("403 - PATCH: responds with error when not admin", async () => {
       const response = await request(app)
-        .put("/api/admin/events/1")
+        .patch("/api/admin/events/1")
         .set("user-role", "user")
         .send({});
 
@@ -200,7 +200,7 @@ describe("Admin Events API", () => {
       );
     });
 
-    test("400 - PUT: responds with error when update data is invalid", async () => {
+    test("400 - PATCH: responds with error when update data is invalid", async () => {
       const invalidUpdate = {
         title: "Invalid Update",
         description: "Test Description",
@@ -216,7 +216,7 @@ describe("Admin Events API", () => {
       };
 
       const response = await request(app)
-        .put("/api/admin/events/1")
+        .patch("/api/admin/events/1")
         .set("user-role", "admin")
         .send(invalidUpdate);
 
@@ -225,8 +225,7 @@ describe("Admin Events API", () => {
     });
 
     test("401 - PUT: responds with error when not authenticated", async () => {
-      const response = await request(app).put("/api/admin/events/1").send({});
-
+      const response = await request(app).patch("/api/admin/events/1").send({});
       expect(response.status).toBe(401);
       expect(response.body.message).toBe("You need to be signed in");
     });

--- a/backend/__tests__/admin/events/adminEventEndpoints.test.js
+++ b/backend/__tests__/admin/events/adminEventEndpoints.test.js
@@ -1,0 +1,25 @@
+describe("PATCH /api/admin/events/:id", () => {
+  // ... other tests ...
+
+  test("401 - PATCH: responds with error when not authenticated", async () => {
+    const eventToUpdate = {
+      title: "Updated Event",
+      description: "Updated description",
+      date: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+      end_date: new Date(
+        Date.now() + 7 * 24 * 60 * 60 * 1000 + 2 * 60 * 60 * 1000
+      ),
+      capacity: 50,
+      location_name: "Updated Location",
+      location_address: "Updated Address",
+      event_type_id: 1,
+    };
+
+    const response = await request(app)
+      .patch("/api/admin/events/1") // Changed from .put to .patch
+      .send(eventToUpdate);
+
+    expect(response.status).toBe(401);
+    expect(response.body.message).toBe("You need to be signed in");
+  });
+});

--- a/backend/__tests__/eventTypes/eventTypesEndpoints.test.js
+++ b/backend/__tests__/eventTypes/eventTypesEndpoints.test.js
@@ -1,0 +1,202 @@
+import app from "../../app/app";
+import db from "../../app/connection";
+import seed from "../../app/db/seeds/seed";
+import testData from "../../app/db/seeds/data/test/index";
+import request from "supertest";
+
+describe("EventTypes API", () => {
+  beforeEach(async () => {
+    await db.query("BEGIN");
+    await seed(testData);
+  });
+
+  afterEach(async () => {
+    await db.query("ROLLBACK");
+  });
+
+  afterAll(async () => {
+    await db.end();
+  });
+
+  describe("GET /api/event-types", () => {
+    test("200 - GET: Returns an array of all event types", async () => {
+      const response = await request(app).get("/api/event-types");
+
+      expect(response.status).toBe(200);
+      expect(Array.isArray(response.body)).toBe(true);
+
+      response.body.forEach((eventType) => {
+        expect(eventType).toMatchObject({
+          id: expect.any(Number),
+          name: expect.any(String),
+          created_at: expect.any(String),
+          updated_at: expect.any(String),
+        });
+      });
+
+      const eventTypeNames = response.body.map((type) => type.name);
+      expect(eventTypeNames).toContain("Workshop");
+      expect(eventTypeNames).toContain("Technology");
+    });
+  });
+
+  describe("POST /api/admin/event-types", () => {
+    test("201 - POST: creates and returns a new event type when authenticated as admin", async () => {
+      const newEventType = {
+        name: "New event type",
+        description: "test event description",
+      };
+      const response = await request(app)
+        .post("/api/admin/event-types")
+        .set("user-role", "admin")
+        .send(newEventType);
+      expect(response.status).toBe(201);
+      expect(response.body).toMatchObject({
+        id: expect.any(Number),
+        name: "New event type",
+        description: "test event description",
+        created_at: expect.any(String),
+        updated_at: expect.any(String),
+      });
+    });
+
+    test("400- POST: returns error when name is missing", async () => {
+      const newEventType = {
+        description: "test event description",
+      };
+
+      const response = await request(app)
+        .post("/api/admin/event-types")
+        .set("user-role", "admin")
+        .send(newEventType);
+
+      expect(response.status).toBe(400);
+      expect(response.body.message).toBe("Missing required field: name");
+    });
+    test("400- POST: returns error when name is missing", async () => {
+      const newEventType = {
+        name: "test event type",
+      };
+
+      const response = await request(app)
+        .post("/api/admin/event-types")
+        .set("user-role", "admin")
+        .send(newEventType);
+
+      expect(response.status).toBe(400);
+      expect(response.body.message).toBe("Missing required field: description");
+    });
+  });
+
+  describe("PATCH /api/admin/event-types/:id", () => {
+    test("200: updates and returns the event type", async () => {
+      const updatedData = {
+        name: "Updated name",
+        description: "Updated description",
+      };
+
+      const response = await request(app)
+        .patch(`/api/admin/event-types/1`)
+        .set("user-role", "admin")
+        .send(updatedData);
+
+      expect(response.status).toBe(200);
+      expect(response.body).toMatchObject({
+        id: 1,
+        name: "Updated name",
+        description: "Updated description",
+        created_at: expect.any(String),
+        updated_at: expect.any(String),
+      });
+    });
+
+    test("404: returns error when event type doesn't exist", async () => {
+      const updatedData = {
+        name: "Updated name",
+        description: "Updated description",
+      };
+
+      const response = await request(app)
+        .patch(`/api/admin/event-types/9999`)
+        .set("user-role", "admin")
+        .send(updatedData);
+
+      expect(response.status).toBe(404);
+      expect(response.body.message).toBe("Event type not found");
+    });
+  });
+
+  describe("DELETE /api/admin/event-types/:id", () => {
+    test("204 - DELETE: deletes the event type when authenticated as admin", async () => {
+      const response = await request(app)
+        .delete("/api/admin/event-types/1")
+        .set("user-role", "admin");
+
+      expect(response.status).toBe(204);
+
+      const checkDeleted = await db.query(
+        "SELECT * FROM event_types WHERE id = $1",
+        [1]
+      );
+      expect(checkDeleted.rows.length).toBe(0);
+    });
+
+    test("404 - DELETE: returns error when event type doesn't exist", async () => {
+      const response = await request(app)
+        .delete("/api/admin/event-types/9999")
+        .set("user-role", "admin");
+
+      expect(response.status).toBe(404);
+      expect(response.body.message).toBe("Event type not found");
+    });
+
+    test("400 - DELETE: returns error when id is invalid", async () => {
+      const response = await request(app)
+        .delete("/api/admin/event-types/not-a-number")
+        .set("user-role", "admin");
+
+      expect(response.status).toBe(400);
+      expect(response.body.message).toBe("Invalid event type ID");
+    });
+
+    test("403 - DELETE: returns error when not admin", async () => {
+      const response = await request(app)
+        .delete("/api/admin/event-types/1")
+        .set("user-role", "user");
+
+      expect(response.status).toBe(403);
+      expect(response.body.message).toBe(
+        "You need to be an admin to carry out this action"
+      );
+    });
+  });
+
+  describe("GET /api/event-types/:id", () => {
+    test("200 - GET: Returns a single event type when it exists", async () => {
+      const response = await request(app).get("/api/event-types/1");
+
+      expect(response.status).toBe(200);
+      expect(response.body).toMatchObject({
+        id: 1,
+        name: expect.any(String),
+        description: expect.any(String),
+        created_at: expect.any(String),
+        updated_at: expect.any(String),
+      });
+    });
+
+    test("404 - GET: Returns error when event type doesn't exist", async () => {
+      const response = await request(app).get("/api/event-types/9999");
+
+      expect(response.status).toBe(404);
+      expect(response.body.message).toBe("Event type not found");
+    });
+
+    test("400 - GET: Returns error when id is invalid", async () => {
+      const response = await request(app).get("/api/event-types/not-a-number");
+
+      expect(response.status).toBe(400);
+      expect(response.body.message).toBe("Invalid event type ID");
+    });
+  });
+});

--- a/backend/app/controllers/auth/login.js
+++ b/backend/app/controllers/auth/login.js
@@ -3,7 +3,6 @@ import * as authService from "../../services/auth/login";
 export const login = async (req, res, next) => {
   try {
     const { email, password } = req.body;
-
     const token = await authService.login(email, password);
     res.status(200).json(token);
   } catch (error) {

--- a/backend/app/controllers/eventTypes/createEventType.js
+++ b/backend/app/controllers/eventTypes/createEventType.js
@@ -1,0 +1,10 @@
+import * as eventTypeService from "../../services/eventTypes/index";
+
+export const createEventType = async (req, res, next) => {
+  try {
+    const eventType = await eventTypeService.createEventType(req.body);
+    res.status(201).json(eventType);
+  } catch (error) {
+    next(error);
+  }
+};

--- a/backend/app/controllers/eventTypes/deleteEventType.js
+++ b/backend/app/controllers/eventTypes/deleteEventType.js
@@ -1,0 +1,23 @@
+import * as eventTypeService from "../../services/eventTypes";
+import { createValidationError } from "../../middleware/errorHandler.js";
+
+export const deleteEventType = async (req, res, next) => {
+  try {
+    const eventTypeId = parseInt(req.params.id);
+
+    if (isNaN(eventTypeId)) {
+      throw createValidationError("Invalid event type ID");
+    }
+
+    await eventTypeService.deleteEventType(eventTypeId);
+    res.status(204).send();
+  } catch (error) {
+    if (error.message === "Event type not found") {
+      return res.status(404).json({ message: error.message });
+    }
+    if (error.name === "ValidationError") {
+      return res.status(400).json({ message: error.message });
+    }
+    next(error);
+  }
+};

--- a/backend/app/controllers/eventTypes/getAllEventTypes.js
+++ b/backend/app/controllers/eventTypes/getAllEventTypes.js
@@ -1,0 +1,10 @@
+import * as eventTypeService from "../../services/eventTypes/getAllEventTypes.js";
+
+export const getAllEventTypes = async (req, res, next) => {
+  try {
+    const eventTypes = await eventTypeService.getAllEventTypes();
+    res.status(200).json(eventTypes);
+  } catch (error) {
+    next(error);
+  }
+};

--- a/backend/app/controllers/eventTypes/getEventTypeById.js
+++ b/backend/app/controllers/eventTypes/getEventTypeById.js
@@ -1,0 +1,23 @@
+import * as eventTypeService from "../../services/eventTypes";
+import { createValidationError } from "../../middleware/errorHandler.js";
+
+export const getEventTypeById = async (req, res, next) => {
+  try {
+    const eventTypeId = parseInt(req.params.id);
+
+    if (isNaN(eventTypeId)) {
+      throw createValidationError("Invalid event type ID");
+    }
+
+    const eventType = await eventTypeService.getEventTypeById(eventTypeId);
+    res.status(200).json(eventType);
+  } catch (error) {
+    if (error.message === "Event type not found") {
+      return res.status(404).json({ message: error.message });
+    }
+    if (error.name === "ValidationError") {
+      return res.status(400).json({ message: error.message });
+    }
+    next(error);
+  }
+};

--- a/backend/app/controllers/eventTypes/index.js
+++ b/backend/app/controllers/eventTypes/index.js
@@ -1,0 +1,5 @@
+export { getAllEventTypes } from "./getAllEventTypes.js";
+export { createEventType } from "./createEventType.js";
+export { updateEventType } from "./updateEventType.js";
+export { deleteEventType } from "./deleteEventType.js";
+export { getEventTypeById } from "./getEventTypeById.js";

--- a/backend/app/controllers/eventTypes/updateEventType.js
+++ b/backend/app/controllers/eventTypes/updateEventType.js
@@ -1,0 +1,26 @@
+import * as eventTypeService from "../../services/eventTypes";
+import { createValidationError } from "../../middleware/errorHandler.js";
+
+export const updateEventType = async (req, res, next) => {
+  try {
+    const eventTypeId = parseInt(req.params.id);
+
+    if (isNaN(eventTypeId)) {
+      throw createValidationError("Invalid event type ID");
+    }
+
+    const updatedEventType = await eventTypeService.updateEventType(
+      eventTypeId,
+      req.body
+    );
+    res.status(200).json(updatedEventType);
+  } catch (error) {
+    if (error.message === "Event type not found") {
+      return res.status(404).json({ message: error.message });
+    }
+    if (error.name === "ValidationError") {
+      return res.status(400).json({ message: error.message });
+    }
+    next(error);
+  }
+};

--- a/backend/app/db/schema/events.sql
+++ b/backend/app/db/schema/events.sql
@@ -7,7 +7,7 @@ CREATE TABLE events (
     end_date TIMESTAMP NOT NULL,
     location_name VARCHAR(255) NOT NULL,
     location_address VARCHAR(255) NOT NULL,
-    event_type_id INTEGER REFERENCES event_types(id),
+    event_type_id INTEGER REFERENCES event_types(id) ON DELETE CASCADE,
     creator_id INTEGER REFERENCES users(id),
     status VARCHAR(50) DEFAULT 'upcoming' CHECK (status IN ('upcoming', 'ongoing', 'completed', 'cancelled')),
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,

--- a/backend/app/middleware/checkValidation.js
+++ b/backend/app/middleware/checkValidation.js
@@ -137,3 +137,15 @@ export const checkEventCapacity = (event, attendees, userId) => {
 
   return true;
 };
+
+export const checkEventType = (eventTypeData) => {
+  const requiredFields = ["name", "description"];
+
+  for (const field of requiredFields) {
+    if (!eventTypeData[field]) {
+      throw createValidationError(`Missing required field: ${field}`);
+    }
+  }
+
+  return eventTypeData;
+};

--- a/backend/app/repositories/eventTypes/createEventType.js
+++ b/backend/app/repositories/eventTypes/createEventType.js
@@ -1,0 +1,16 @@
+import db from "../../connection.js";
+import { handleDatabaseError } from "../../middleware/errorHandler.js";
+
+export const createEventType = async (eventTypeData) => {
+  try {
+    const { rows } = await db.query(
+      `INSERT INTO event_types (name, description)
+       VALUES ($1, $2)
+       RETURNING id, name, description, created_at, updated_at`,
+      [eventTypeData.name, eventTypeData.description]
+    );
+    return rows[0];
+  } catch (error) {
+    handleDatabaseError(error);
+  }
+};

--- a/backend/app/repositories/eventTypes/deleteEventType.js
+++ b/backend/app/repositories/eventTypes/deleteEventType.js
@@ -1,0 +1,16 @@
+import db from "../../connection.js";
+import { handleDatabaseError } from "../../middleware/errorHandler.js";
+
+export const deleteEventType = async (id) => {
+  try {
+    const { rows } = await db.query(
+      `DELETE FROM event_types
+       WHERE id = $1
+       RETURNING id`,
+      [id]
+    );
+    return rows[0];
+  } catch (error) {
+    handleDatabaseError(error);
+  }
+};

--- a/backend/app/repositories/eventTypes/getAllEventTypes.js
+++ b/backend/app/repositories/eventTypes/getAllEventTypes.js
@@ -1,0 +1,16 @@
+import db from "../../connection.js";
+
+export const getAllEventTypes = async () => {
+  const query = `
+    SELECT 
+      id,
+      name,
+      created_at,
+      updated_at
+    FROM event_types
+    ORDER BY name ASC
+  `;
+
+  const result = await db.query(query);
+  return result.rows;
+};

--- a/backend/app/repositories/eventTypes/getEventTypeById.js
+++ b/backend/app/repositories/eventTypes/getEventTypeById.js
@@ -1,0 +1,16 @@
+import db from "../../connection.js";
+import { handleDatabaseError } from "../../middleware/errorHandler.js";
+
+export const getEventTypeById = async (id) => {
+  try {
+    const { rows } = await db.query(
+      `SELECT id, name, description, created_at, updated_at
+       FROM event_types
+       WHERE id = $1`,
+      [id]
+    );
+    return rows[0];
+  } catch (error) {
+    handleDatabaseError(error);
+  }
+};

--- a/backend/app/repositories/eventTypes/index.js
+++ b/backend/app/repositories/eventTypes/index.js
@@ -1,0 +1,5 @@
+export { getAllEventTypes } from "./getAllEventTypes.js";
+export { createEventType } from "./createEventType.js";
+export { updateEventType } from "./updateEventType.js";
+export { deleteEventType } from "./deleteEventType.js";
+export { getEventTypeById } from "./getEventTypeById.js";

--- a/backend/app/repositories/eventTypes/updateEventType.js
+++ b/backend/app/repositories/eventTypes/updateEventType.js
@@ -1,0 +1,20 @@
+import db from "../../connection.js";
+import { handleDatabaseError } from "../../middleware/errorHandler.js";
+
+export const updateEventType = async (id, eventTypeData) => {
+  try {
+    const { rows } = await db.query(
+      `UPDATE event_types
+       SET name = $1, 
+           description = $2,
+           updated_at = CURRENT_TIMESTAMP
+       WHERE id = $3
+       RETURNING id, name, description, created_at, updated_at`,
+      [eventTypeData.name, eventTypeData.description, id]
+    );
+
+    return rows[0];
+  } catch (error) {
+    handleDatabaseError(error);
+  }
+};

--- a/backend/app/repositories/users/getAllEvents.js
+++ b/backend/app/repositories/users/getAllEvents.js
@@ -13,7 +13,7 @@ export const getAllEvents = async ({
   const sortField = validSortFields.includes(sort) ? sort : "date";
   const sortOrder = validOrders.includes(order.toLowerCase()) ? order : "asc";
 
-  const eventsQuery = `
+  const eventsQueryStr = `
     SELECT 
       events.*,
       event_types.name as event_type_name,
@@ -26,7 +26,7 @@ export const getAllEvents = async ({
     LIMIT $1 OFFSET $2
   `;
 
-  const result = await db.query(eventsQuery, [limit, offset]);
+  const result = await db.query(eventsQueryStr, [limit, offset]);
 
   const eventIds = result.rows.map((event) => event.id);
   const { rows: allAttendees } = await db.query(

--- a/backend/app/routes/index.js
+++ b/backend/app/routes/index.js
@@ -3,6 +3,7 @@ import * as adminEventController from "../controllers/admin/events/index";
 import * as usersController from "../controllers/users/index";
 import * as adminUserController from "../controllers/admin/users/index";
 import * as authController from "../controllers/auth/index.js";
+import * as eventTypeController from "../controllers/eventTypes/index.js";
 
 import { errorHandler } from "../middleware/errorHandler.js";
 import { checkAdmin, checkUser } from "../middleware/auth.js";
@@ -14,7 +15,7 @@ router.post("/api/auth/login", authController.login);
 
 // Admin Routes
 router.post("/api/admin/events", checkAdmin, adminEventController.createEvent);
-router.put(
+router.patch(
   "/api/admin/events/:id",
   checkAdmin,
   adminEventController.updateEvent
@@ -28,6 +29,21 @@ router.patch(
   "/api/admin/users/:id",
   checkAdmin,
   adminUserController.updateUser
+);
+router.post(
+  "/api/admin/event-types",
+  checkAdmin,
+  eventTypeController.createEventType
+);
+router.patch(
+  "/api/admin/event-types/:id",
+  checkAdmin,
+  eventTypeController.updateEventType
+);
+router.delete(
+  "/api/admin/event-types/:id",
+  checkAdmin,
+  eventTypeController.deleteEventType
 );
 
 //User Routes
@@ -47,6 +63,10 @@ router.delete(
 );
 router.get("/api/users", usersController.getAllUsers);
 router.post("/api/users", usersController.createUser);
+
+// Event Types routes
+router.get("/api/event-types", eventTypeController.getAllEventTypes);
+router.get("/api/event-types/:id", eventTypeController.getEventTypeById);
 
 // Error handling
 router.use(errorHandler);

--- a/backend/app/services/eventTypes/createEventType.js
+++ b/backend/app/services/eventTypes/createEventType.js
@@ -1,0 +1,8 @@
+import { checkEventType } from "../../middleware/checkValidation";
+import * as eventTypeRepository from "../../repositories/eventTypes/index";
+
+export const createEventType = async (eventTypeData) => {
+  checkEventType(eventTypeData);
+  const newEventType = await eventTypeRepository.createEventType(eventTypeData);
+  return newEventType;
+};

--- a/backend/app/services/eventTypes/deleteEventType.js
+++ b/backend/app/services/eventTypes/deleteEventType.js
@@ -1,0 +1,10 @@
+import * as eventTypeRepository from "../../repositories/eventTypes";
+
+export const deleteEventType = async (id) => {
+  const existingEventType = await eventTypeRepository.getEventTypeById(id);
+  if (!existingEventType) {
+    throw new Error("Event type not found");
+  }
+
+  return await eventTypeRepository.deleteEventType(id);
+};

--- a/backend/app/services/eventTypes/getAllEventTypes.js
+++ b/backend/app/services/eventTypes/getAllEventTypes.js
@@ -1,0 +1,6 @@
+import * as eventTypeRepository from "../../repositories/eventTypes/getAllEventTypes.js";
+
+export const getAllEventTypes = async () => {
+  const eventTypes = await eventTypeRepository.getAllEventTypes();
+  return eventTypes;
+};

--- a/backend/app/services/eventTypes/getEventTypeById.js
+++ b/backend/app/services/eventTypes/getEventTypeById.js
@@ -1,0 +1,11 @@
+import * as eventTypeRepository from "../../repositories/eventTypes";
+
+export const getEventTypeById = async (id) => {
+  const eventType = await eventTypeRepository.getEventTypeById(id);
+
+  if (!eventType) {
+    throw new Error("Event type not found");
+  }
+
+  return eventType;
+};

--- a/backend/app/services/eventTypes/index.js
+++ b/backend/app/services/eventTypes/index.js
@@ -1,0 +1,5 @@
+export { getAllEventTypes } from "./getAllEventTypes.js";
+export { createEventType } from "./createEventType.js";
+export { updateEventType } from "./updateEventType.js";
+export { deleteEventType } from "./deleteEventType.js";
+export { getEventTypeById } from "./getEventTypeById.js";

--- a/backend/app/services/eventTypes/updateEventType.js
+++ b/backend/app/services/eventTypes/updateEventType.js
@@ -1,0 +1,16 @@
+import { checkEventType } from "../../middleware/checkValidation";
+import * as eventTypeRepository from "../../repositories/eventTypes";
+
+export const updateEventType = async (id, eventTypeData) => {
+  const existingEventType = await eventTypeRepository.getEventTypeById(id);
+  if (!existingEventType) {
+    throw new Error("Event type not found");
+  }
+  checkEventType(eventTypeData);
+  const updatedEventType = await eventTypeRepository.updateEventType(
+    id,
+    eventTypeData
+  );
+
+  return updatedEventType;
+};


### PR DESCRIPTION
# Event Types API Endpoints

Added complete CRUD functionality for event types with proper error handling and validation.

## New Endpoints

### Public Routes
- `GET /api/event-types` - Get all event types
- `GET /api/event-types/:id` - Get a specific event type

### Admin Routes
- `POST /api/admin/event-types` - Create new event type
- `PATCH /api/admin/event-types/:id` - Update existing event type
- `DELETE /api/admin/event-types/:id` - Delete event type